### PR TITLE
Update SSJ dependency to latest version

### DIFF
--- a/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: SSJ Simulation Engine
 Bundle-SymbolicName: org.palladiosimulator.simulation.abstractsimengine.ssj;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: palladiosimulator.org
-Require-Bundle: ca.umontreal.iro.lecuyer.ssj,
- org.apache.log4j,
- de.uka.ipd.sdq.simulation.abstractsimengine;bundle-version="1.0.0"
+Require-Bundle: org.apache.log4j,
+ de.uka.ipd.sdq.simulation.abstractsimengine;bundle-version="1.0.0",
+ ca.umontreal.iro.simul.ssj;bundle-version="3.3.1"
 Bundle-ClassPath: .
 Export-Package: org.palladiosimulator.simulation.abstractsimengine.ssj
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJEntity.java
+++ b/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJEntity.java
@@ -3,9 +3,9 @@
  */
 package org.palladiosimulator.simulation.abstractsimengine.ssj;
 
-import umontreal.iro.lecuyer.simevents.Event;
 import de.uka.ipd.sdq.simulation.abstractsimengine.AbstractSimEntityDelegator;
 import de.uka.ipd.sdq.simulation.abstractsimengine.IEntity;
+import umontreal.ssj.simevents.Event;
 
 /**
  * @author Steffen Becker

--- a/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJExperiment.java
+++ b/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJExperiment.java
@@ -1,8 +1,8 @@
 package org.palladiosimulator.simulation.abstractsimengine.ssj;
 
-import umontreal.iro.lecuyer.simevents.Simulator;
-import umontreal.iro.lecuyer.simevents.eventlist.SplayTree;
 import de.uka.ipd.sdq.simulation.abstractsimengine.AbstractExperiment;
+import umontreal.ssj.simevents.Simulator;
+import umontreal.ssj.simevents.eventlist.SplayTree;
 
 /**
  * @author Steffen Becker

--- a/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJSimEvent.java
+++ b/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJSimEvent.java
@@ -2,11 +2,11 @@ package org.palladiosimulator.simulation.abstractsimengine.ssj;
 
 import org.apache.log4j.Logger;
 
-import umontreal.iro.lecuyer.simevents.Event;
 import de.uka.ipd.sdq.simulation.abstractsimengine.AbstractSimEntityDelegator;
 import de.uka.ipd.sdq.simulation.abstractsimengine.AbstractSimEventDelegator;
 import de.uka.ipd.sdq.simulation.abstractsimengine.IEntity;
 import de.uka.ipd.sdq.simulation.abstractsimengine.ISimEvent;
+import umontreal.ssj.simevents.Event;
 
 /**
  * @author Steffen Becker

--- a/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJSimProcess.java
+++ b/bundles/org.palladiosimulator.simulation.abstractsimengine.ssj/src/org/palladiosimulator/simulation/abstractsimengine/ssj/SSJSimProcess.java
@@ -5,12 +5,12 @@ package org.palladiosimulator.simulation.abstractsimengine.ssj;
 
 import org.apache.log4j.Logger;
 
-import umontreal.iro.lecuyer.simevents.Event;
-import umontreal.iro.lecuyer.simevents.Simulator;
 import de.uka.ipd.sdq.simulation.abstractsimengine.AbstractSimProcessDelegator;
 import de.uka.ipd.sdq.simulation.abstractsimengine.processes.ProcessState;
 import de.uka.ipd.sdq.simulation.abstractsimengine.processes.SimProcessThreadingStrategy;
 import de.uka.ipd.sdq.simulation.abstractsimengine.processes.SimulatedProcess;
+import umontreal.ssj.simevents.Event;
+import umontreal.ssj.simevents.Simulator;
 
 /**
  * Simulation Process implementation for SSJ

--- a/releng/org.palladiosimulator.simucomssj.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.simucomssj.targetplatform/tp.target
@@ -2,8 +2,16 @@
 <?pde version="3.8"?><target name="org.palladiosimulator.simucomssj Target Platform" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
+<unit id="ca.umontreal.iro.ssj.feature.feature.group" version="3.3.1"/>
+<repository location="https://sdqweb.ipd.kit.edu/eclipse/palladio/thirdparty/thirdpartylibrary/releases/latest"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
 <unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="1.0.2.201709282218"/>
 <repository location="https://sdqweb.ipd.kit.edu/eclipse/thirdpartywrapper/releases/latest/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+<unit id="ca.umontreal.iro.ssj.feature.feature.group" version="3.3.1"/>
+<repository location="https://sdqweb.ipd.kit.edu/eclipse/palladio/thirdparty/thirdpartylibrary/nightly/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
 <unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="1.0.2.201709282218"/>


### PR DESCRIPTION
The SSJ version is updated in particular to reflect the license change. Furthermore, we are now able to drop the custom SSJ bundle with platform specific fragments from the legacy ThirdPartyWrapper.